### PR TITLE
ensure right sidebar stays in view on scroll

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1,7 +1,3 @@
-main {
-  overflow-x: hidden;
-}
-
 main article header h1 {
   margin-bottom: 20px;
 }


### PR DESCRIPTION
The intended behavior of the site is that when the main content is scrolled, the right sidebar should stay in view. Right now it does not