### PR TITLE
[dip-1] add trade_ids in PaymentObject

### DIFF
--- a/dips/dip-1.mdx
+++ b/dips/dip-1.mdx
@@ -386,6 +386,7 @@ Some fields are immutable after they are defined once. Others can be updated mul
 | recipient_signature | str | N | Signature of the recipient of this transaction encoded in hex. The is signed with the compliance key of the recipient VASP and is used for on-chain attestation from the recipient party.  This may be omitted on blockchains which do not require on-chain attestation. Generated via [Recipient Signature](#recipient-signature) |
 | action | [`PaymentActionObject`](#paymentactionobject) | Y | Number of cryptocurrency + currency type (XUS, etc.)<a href="#note1" id="note1ref"><sup>1</sup></a> + type of action to take. This field is mandatory and immutable |
 | description | str | N | Description of the payment. To be displayed to the user. Unicode utf-8 encoded max length of 255 characters. This field is optional but can only be written once.
+| trade_ids | list of str | N | (Only relevant when this payment is a coin trade) the list of trade ids to settle. Trade id is Unicode utf-8 encoded max length of 255 characters. This field is optional but can only be written once.
 
 ```
 {


### PR DESCRIPTION
The motivation is to support passing trade_ids in Off Chain / Travel Rule protocol, such that mapping among trade_id, reference_id and on chain transfer can be mapped.

Please see details in https://docs.google.com/document/d/1DNaRzSjHGU7HD8xrEbU_cg3JY5apQI5VQcIpHM44EAI/edit?usp=sharing