### PR TITLE
Dip 158 remove ready for settlement

### DIFF
--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -385,7 +385,7 @@ A PaymentSenderObject represents the person in the payment. In P2M scenarios it 
 
 |Field|Type|Required?|Description|
 |-|-|-|-|
-| account_address | str | Y | Address of the receiver account. The addresses are encoded using bech32| 
+| account_address | str | Y | Address of the sender account. The addresses are encoded using bech32| 
 |payer_data|[PayerDataObject](#payerdataobject)|Y|The details of the payer|
 
 ```

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -1,42 +1,36 @@
 ---
 dip: 158
-title: P2M (eCommerce) Payments Off-Chain Protocol
+title: P2M Charge Payment - Off-Chain Protocol
 authors: Yinon Zohar, Daniel Prinz, David Wolinsky, Dimitri Roche
 status: Draft
 type: Standard
 created: 03/15/2021
-updated: 05/14/2021
+updated: 05/23/2021
 requires: DIP-1, DIP-5, DIP-161
 ---
 
 # Summary
-This DIP leverages the off-chain protocol defined in [DIP-1](https://github.com/diem/dip/blob/main/dips/dip-1.mdx) and extends it to enable eCommerce P2M payments (Peer To Merchant) of the following types:
-* Charge
-* Auth / Capture
+This DIP leverages the off-chain protocol defined in [DIP-1](https://github.com/diem/dip/blob/main/dips/dip-1.mdx) and extends it to enable P2M Charge payment.
 
-This DIP defines the type of eCommerce P2M payments, corresponding requests and the payment structures. 
+This DIP defines the type of the P2M payments, corresponding requests and the payment structures. 
  
-This DIP makes the Auth/Capture section in [DIP-8](https://dip.diem.com/dip-8/#authcapture) redundant. The auth/capture section in DIP-8 is to be disregarded and will be removed in a future version of DIP-8. 
-
 This DIP does NOT include payment flows which require funds pull pre-approval such as subscription and recurring payments. 
 
 This DIP makes use of the `result` field added to the `CommandResponseObject` as described in [DIP-161](https://github.com/diem/dip/blob/main/dips/dip-161.md)
 
 ---
 # Abstract / Motivation
-This DIP is an extension of the Off-Chain Protocol to support more advanced payment functionality - particularly eCommerce P2M payments. 
+This DIP is an extension of the Off-Chain Protocol to support more advanced payment functionality - particularly eCommerce P2M Charge payment.
+Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured (and submit a corresponding transaction on-chain and actually transfer the funds). 
+
 ## How P2M Payments Differ from P2P Transfers 
 There are several key differences between the process of paying a merchant (P2M) and a simple P2P transfer:
 ||P2M|P2P|
 |-|-|-|
 |**Payer Data**|Customer details are required for **every** payment / purchase in order to perform risk checks and apply AML policies|Required only for transfers for which Travel Rule applies. i.e., over 1000 USD|
-|**Payment Owner**|The merchant, i.e. the receiver of funds, "drives" the process and controls the type of payment and its timing. For example, the merchant will decide when to capture the previously authorized funds and whether to capture the entire payment amount or only partial amount |The payer, i.e. the sender of funds, determines the nature of the transfer|
+|**Payment Owner**|The merchant, i.e. the receiver of funds, "drives" the process and determines the payment details|The payer, i.e. the sender of funds, determines the nature of the transfer|
 |**Reconciliation**|The merchant requires a way to correlate the transfer of funds to a payment or payment request for reconciliation purposes|No reconciliation|
 
-## P2M Payment Types
-There are two types of P2M payments described in this document: 
-1. **Charge**. Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured 
-2. **Auth / Capture**. Auth / Capture payment, as the name suggests, means that the payment is divided to two steps: Authorization and Capture. Successful Authorization implies that the funds are locked so they can later be captured
 ---
 # Glossary
 For the sake of simplicity, we use the following terms:
@@ -53,7 +47,7 @@ See [Appendix A](#appendix-a---prerequisite-sharing-common-payment-identifier-an
 
 ---
 # P2M Off-Chain Protocol Specification
-This section specifies P2M payment types, required structures, payloads and expected sequence of calls based on this protocol.
+This section specifies P2M payment type, required structures, payloads and expected sequence of calls based on this protocol.
 
 Content:
 * [High Level Flow and Payment Types](#high-level-flow-and-payment-types)
@@ -65,59 +59,43 @@ Content:
 ---
 ## High-Level Flow and Payment Types
 ---
-The high-level flow of an eCommerce P2M payment (regardless of the type) is:
+The high-level flow of an eCommerce P2M payment is:
 1. On the merchant's checkout page the customer chooses to pay with Diem
 2. The merchant transmits the payment details to its VASP (receiver VASP) so the latter can generate a payment request with Diem  
 3. The the receiver VASP generates a payment request with all details needed to identify this payment later in the process, provides it to the merchant and makes it available to the customer's Diem wallet (the customer's VASP or sender)
 4. The sender VASP parses the payment request (e.g. by scanning the payment request QR) and uses the provided payment identifier to get the payment details. This is the first step of the off-chain protocol
 5. The wallet then presents the requested payment details to the customer so the customer can review the payment
 6. The customer approves the payment request in the wallet
-7. The wallet initializes the payment protocol (off-chain) which will end (if successful) with the funds being authorized or charged (depending on the payment type). Successful completion implies that the receiving VASP was satisfied with the payer information provided and the sender VASP was satisfied with the merchant information provided. **Note** that if the payment amount exceeds the amount that requires a dual attestation signature to be submitted to the blockchain, it must be part of the on-chain transaction submitted  
+7. The wallet initializes the payment protocol (off-chain) which will end (if successful) with the funds being charged. Successful completion implies that the receiving VASP was satisfied with the payer information provided and the sender VASP was satisfied with the merchant information provided. **Note** that if the payment amount exceeds the amount that requires a dual attestation signature to be submitted to the blockchain, it must be part of the on-chain transaction submitted  
 
 ### **Charge Payment Type** 
 Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured.
-
 As soon as the funds are captured, i.e. the sender agreed to the payment terms, the sender VASP is expected to submit a corresponding transaction on-chain and actually transfer the funds. 
 
-
-### **Auth / Capture Payment Type**
-Auth / Capture payment, as the name suggests, means that the payment is divided into two steps:
-* Authorization
-* Capture
- 
-The Authorization step ends when the funds are locked by the sender VASP so they can later be captured by the receiver VASP. Note that the capture may occur several days after a successful authorization. It is up to the receiver VASP to decide on the timing. In addition, the receiver may choose to capture only a partial amount rather than the full amount which was authorized. 
-
-This payment type is useful for delayed fulfillment or pre-authorizing an expected amount to ensure that an amount can be captured after services are rendered. 
-
-Off-chain negotiations for Auth / Capture payment are divided into two steps accordingly. First, off-chain negotiations will result in funds being authorized, i.e. locked by the wallet. Later, a separate off-chain negotiation triggered by the receiving VASP will capture the funds. Note that for the time being, multi-capture is not supported and there can be only a single capture request.
-
-Successful authorization will not necessarily be followed by a successful capture. It is possible that the receiver will choose to cancel the authorization and essentially void the payment before it was captured. One possible reason to void a payment is that the products for which an amount was locked are out of stock and cannot be fulfilled.
+### **Other Payment Types (future)**
+More advanced eCommerce payments flows will require additional payment types which will be be defined in future DIPs.
+Some examples for such flows are:
+* Auth / Capture
+* Subscription payment
+* Recurring payment
 
 ---
 ## Sender / Receiver Interface
 ---
-This section describes a set of functionalities / activities that should be made available by a Sender and Receiver VASPs in order to support P2M flows based on this DIP. Each functionality can be conceptually compared to an API endpoint. Similar to API documentation, it includes the expected input and output for each functionality.
+This section describes a set of functionalities / activities that should be made available by a Sender and Receiver VASPs in order to support P2M Charge flow based on this DIP. Each functionality can be conceptually compared to an API endpoint. Similar to API documentation, it includes the expected input and output for each functionality.
 
 ## Command Types
 The following is a list of new values for the `command_type` field of the `CommandRequestObject`. Each command type denotes a step in the off-chain negotiations and specifies the data of the requests and the response 
 * `GetPaymentInfo` - Allows obtaining payment information based on reference id
 * `InitChargePayment` - Initializes a payment process of type `charge`
-* `InitAuthorizePayment` - Initializes a payment process of type `auth`
 * `ReadyForSettlementNotification` - Notifies the payment is ready for settlement on-chain
-* `AuthorizedNotification` - Notifies that payment funds are authorized (locked) for future capture
-* `CapturePayment` - Request to capture authorized (locked) funds 
-* `VoidPayment` - Voids a payment
 * `AbortPayment` - Aborts a payment
 
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
 |[GetPaymentInfo](#getpaymentinfo)|Sender > Receiver|By providing the object reference id the wallet can retrieve the object information from the receiving VASP. In most cases, this would be the first command sent by the wallet. The wallet is not expected to provide any payer data at this stage|Reference ID|Payment Details ; Business Data|
 |[InitChargePayment](#initchargepayment)|Sender > Receiver|This functionality allows the wallet to init the payment process based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data|(optional) Recipient Signature|
-|[InitAuthorizePayment](#initauthorizepayment)|Sender > Receiver|This functionality allows the wallet to init the payment process based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data||
 |[ReadyForSettlementNotification](#readyforsettlementnotification)|Sender > Receiver|This functionality allows the wallet to indicate the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after declaring it is ready|Reference ID||
-|[AuthorizedNotification](#authorizednotification)|Sender > Receiver|This functionality allows the wallet to indicate funds are locked for future capture. Relevant only for Auth / Capture payments|Reference ID||
-|[CapturePayment](#capturepayment)|Receiver > Sender|This functionality allows the receiver to capture the locked (authorized) funds or part of it. Relevant only for Auth / Capture payments. This optionally includes the recipient signature for dual attestation scenario if needed|Reference ID ; (optional) Amount ; (optional) Recipient Signature||
-|[VoidPayment](#voidpayment)|Receiver > Sender|This functionality allows the receiver to void the payment. For example, the merchant voided the payment because the purchased products are out of stock. Relevant only for Auth / Capture payments|Reference ID||
 |[AbortPayment](#abortpayment)|Sender > Receiver / Receiver > Sender|This functionality allows both parties to abort the payment. For example, the receiver may want to abort the payment following failed risk checks|Reference ID||
 
 ---
@@ -138,49 +116,17 @@ Each scenario is expressed using a sequence of Sender / Receiver functionality.
 #### Charge Sequence Diagram
 ![Charge Sequence Diagram](https://static.swimlanes.io/13ec145db305a3c02323bb3288db52a3.png)
 
-### Authorization Sequence (Auth / Capture)
-| Step | Command Type | Triggered by | Description |
-|-|-|-|-|
-|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|InitAuthorizePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
-|3|AuthorizedNotification|Sender|The wallet indicates the funds are locked for a future capture|
-
-#### Authorization Sequence Diagram
-![Authorize Sequence Diagram](https://static.swimlanes.io/b2845002a924656417266baeda298a94.png)
-
-### Capture Sequence (Auth / Capture)
-IMPORTANT: Successful authorization is a precondition to capture
-| Step |Command Type|Triggered by | Description |
-|-|-|-|-|
-|1|CapturePayment|Receiver|The receiver requests to capture the authorized funds or part of it|
-|2|ReadyForSettlementNotification|Sender|The wallet indicates the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after this step|
-
-#### Capture Sequence Diagram
-![Capture Sequence Diagram](https://static.swimlanes.io/b2e1f8e64c03ba324cea72b9f021f7d8.png)
-
-### Void Sequence (Auth / Capture)
-IMPORTANT: Successful authorization is a precondition to void
-| Step |Command Type|Triggered by | Description |
-|-|-|-|-|
-|1|VoidPayment|Receiver|Receiving VASP wants to void the payment. For example, the merchant voided the payment because the purchased products are out of stock|
-
 ### Risk Checks Failed (Init Payment Error)
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|InitChargePayment / InitAuthorizePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data.  Risk checks failed. Receiver will respond with PaymentCommandErrorObject where the error_code is `risk_checks_failed`|
+|2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data.  Risk checks failed. Receiver will respond with PaymentCommandErrorObject where the error_code is `risk_checks_failed`|
 
-### Invalid Command Type (Premature Capture Attempt Error)
+### Invalid Command Type (Premature Settlement Error)
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|CapturePayment|Sender|Instead of initializing the payment, the wallet wrongly attempts to capture the payment. Receiver will respond with PaymentCommandErrorObject where the error_code is `invalid_command_type`|
-
-### Payment Type Mismatch (Init Payment Error) 
-| Step |Command Type| Triggered by | Description |
-|-|-|-|-|
-|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the `charge` payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|InitAuthorizePayment|Sender|Following customer approval the wallet attempts to initialize an `auth` payment. Receiver will respond with PaymentCommandErrorObject where the error_code is `payment_type_mismatch`|
+|2|ReadyForSettlementNotification|Sender|Instead of initializing the payment, the wallet wrongly notifies that the payment is ready for settlement. Receiver will respond with PaymentCommandErrorObject where the error_code is `invalid_command_type`|
 
 ### Abort Sequence - Customer Rejected the Payment Request
 | Step |Command Type| Triggered by | Description |
@@ -192,8 +138,14 @@ IMPORTANT: Successful authorization is a precondition to void
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|InitChargePayment / InitAuthorizePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
+|2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
 |3|AbortPayment|Sender|Sender decided to abort. Can happen if the sender does not approve merchant data provided by the receiver|
+
+### Abort Sequence - Insufficient Funds
+| Step |Command Type| Triggered by | Description |
+|-|-|-|-|
+|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data|
+|2|AbortPayment|Sender|After getting the payments details from the receiver, the wallet verifies the customer has sufficient funds to complete the payment. If not (and the customer cannot/does not top up the account balance), the wallet should respond with AbortPayment. It is recommended to include a descriptive abort_message|
 
 ---
 ## Request / Response Payload
@@ -321,59 +273,6 @@ Field|Type|Required?|Description|
 }
 
 ```
-### InitAuthorizePayment
-| Command Type |Direction| Description | Request Data | Response Data |
-|-|-|-|-|-|
-|InitChargePayment|Sender > Receiver|This functionality allows the wallet to init the payment process for payments of type `auth` based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data||
-
-#### InitAuthorizePayment Request
-Field|Type|Required?|Description|
-|-|-|-|-|
-|sender|[PaymentSenderObject](#paymentsenderobject)|Y|Minimal payer information required for the receiving VASP to enforce AML and perform risk checks|
-|reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
-
-```
-{
-  "_ObjectType": "CommandRequestObject",
-  "command_type": "InitAuthorizePayment",
-  "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
-  "command": {
-    "_ObjectType": "InitAuthorizePayment",
-    "sender": {
-      "account_address": "dm1pg9q5zs2pg9q5zs2pg9q5zs2pg9skzctpv9skzcg9kmwta",
-      "payer_data": {
-        "given_name": "Alice",
-        "surname": "Cooper",
-        "address": {
-          "city": "Sunnyvale",
-          "country": "US",
-          "line1": "1234 Maple Street",
-          "line2": "Apartment 123",
-          "postal_code": "12345",
-          "state": "California"
-        },
-        "national_id_data": {
-          "id_value": "123456789",
-          "country": "US",
-          "type": "SSN"
-        } 
-      }          
-    },
-    "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98"			    
-  }                      
-}
-
-```
-#### InitAuthorizePayment Response
-```
-{
-  "_ObjectType": "CommandResponseObject",
-  "status": "success",
-  "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"
-}
-
-```
-
 ### ReadyForSettlementNotification
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
@@ -401,102 +300,6 @@ Field|Type|Required?|Description|
   "_ObjectType": "CommandResponseObject",
   "status": "success",
   "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"    
-}
-```
-
-### AuthorizedNotification
-| Command Type |Direction| Description | Request Data | Response Data |
-|-|-|-|-|-|
-|AuthorizedNotification|Sender > Receiver|This functionality allows the wallet to indicate funds are locked for future capture. Relevant only for Auth / Capture payments|Reference ID|
-
-#### AuthorizedNotification Request
-Field|Type|Required?|Description|
-|-|-|-|-|
-|reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
-```
-{
-  "_ObjectType": "CommandRequestObject",
-  "command_type": "AuthorizedNotification",
-  "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
-  "command": {
-    "_ObjectType": "AuthorizedNotification",
-    "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98"
-  }  
-}
-
-```
-#### AuthorizedNotification Response
-```
-{
-  "_ObjectType": "CommandResponseObject",
-  "status": "success",
-  "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"    
-}
-```
-
-### CapturePayment
-| Command Type |Direction| Description | Request Data | Response Data |
-|-|-|-|-|-|
-|CapturePayment|Receiver > Sender|This functionality allows the receiver to capture the locked (authorized) funds or part of it. Relevant only for Auth / Capture payments|Reference ID ; (optional) Amount ; (optional) Recipient Signature||
-
-#### CapturePayment Request
-Field|Type|Required?|Description|
-|-|-|-|-|
-|reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
-| amount | uint | N | Amount to capture. Base units are the same as for on-chain transactions for this currency. Amount can equal or lower than the authorized amount|
-| currency | enum | N | One of the supported on-chain currency types, e.g. XUS. Must be the same as the authorized currency |
-|recipient_signature|str|N| Signature of the recipient of this transaction encoded in hex. A metadata payload is signed with the compliance key of the recipient VASP and is used for on-chain attestation from the recipient party.  This may be omitted on Blockchains which do not require on-chain attestation. Generated via [Recipient Signature](https://github.com/diem/dip/blob/main/dips/dip-1.mdx#recipient-compliance-signature)|
-
-```
-{
-  "_ObjectType": "CommandRequestObject",
-  "command_type": "CapturePayment",
-  "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
-  "command": {
-    "_ObjectType": "CapturePayment",      
-    "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98", 
-    "recipient_signature": "..."
-  }
-}
-
-```
-#### CapturePayment Response
-```
-{
-  "_ObjectType": "CommandResponseObject",
-  "status": "success",
-  "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"    
-}
-```
-
-### VoidPayment
-| Command Type |Direction| Description | Request Data | Response Data |
-|-|-|-|-|-|
-|VoidPayment|Receiver > Sender|This functionality allows the receiver to void the payment. For example, the merchant voided the payment because the purchased products are out of stock. Relevant only for Auth / Capture payments|Reference ID||
-
-#### VoidPayment Request
-Field|Type|Required?|Description|
-|-|-|-|-|
-|reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
-|void_message|str|N|Additional information about the reason for voiding this payment|
-```
-{
-  "_ObjectType": "CommandRequestObject",
-  "command_type": "VoidPayment",
-  "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
-  "command": {
-    "_ObjectType": "VoidPayment",
-    "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98",
-    "void_message": "void message"
-  }
-}
-```
-#### VoidPayment Response
-```
-{
-  "_ObjectType": "CommandResponseObject",
-  "status": "success",
-  "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"
 }
 ```
 ### AbortPayment
@@ -642,15 +445,15 @@ Information about the payment type (i.e. action), amount and currency.
 |-----|----|---------|-----------|
 | amount | uint | Y | Amount of the transfer.  Base units are the same as for on-chain transactions for this currency.  For example, if DiemUSD is represented on-chain where "1" equals 1e-6 dollars, then "1" equals the same amount here.  For any currency, the on-chain mapping must be used for amounts. |
 | currency | enum | Y | One of the supported on-chain currency types, e.g. XUS|
-| action | [Action enum](#action-enum) | Y | Populated in the request.  This value indicates the requested action to perform. For immediate capture and P2P transfer, "charge" is used.  For auth and capture, "auth" and "capture" should be used. "capture" can only be performed after a valid "auth" |
-| valid_until | uint | N | Unix timestamp indicating until when the payment can be authorized. Once this time has been reached, an attempt to authorize and lock the funds will be rejected. One should consider limiting this period to several minutes (e.g. 30 minutes) which should suffice for the customer to approve or reject the payment request|
+| action | [Action enum](#action-enum) | Y | Populated in the request.  This value indicates the requested action to perform. At the moment only `charge` value is supported (for immediate capture and P2P transfer)|
+| valid_until | uint | N | Unix timestamp indicating until when the payment can be completed. Once this time has been reached, an attempt to complete the payment and transfer the funds will be rejected. One should consider limiting this period to several minutes (e.g. 30 minutes) which should suffice for the customer to approve or reject the payment request|
 | timestamp | uint | Y | Unix timestamp indicating the time that the payment Command was created.|
 
 ```
 {
     "amount": 100000000,
     "currency": "XUS",
-    "action": "auth",
+    "action": "charge",
     "valid_until": 74000,
     "timestamp": 72322,
 }
@@ -658,8 +461,6 @@ Information about the payment type (i.e. action), amount and currency.
 ### Action Enum
 The following values are allowed for the Action Enum
 * `charge`
-* `auth`
-* `capture`
 
 ## AddressObject
 Represents a physical address
@@ -733,7 +534,6 @@ For example, a response of GetPaymentInfo in which the refernce_id provided was 
 * `payment_type_mismatch` 
 * `invalid_command_type`
 * `unspecified_error`
-  
 
 ---
 # Appendix A - Prerequisite: Sharing Common Payment Identifier and Address

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -114,7 +114,7 @@ Each scenario is expressed using a sequence of Sender / Receiver functionality.
 |3|ReadyForSettlementNotification|Sender|The wallet indicates the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after this step|
 
 #### Charge Sequence Diagram
-![Charge Sequence Diagram](https://static.swimlanes.io/13ec145db305a3c02323bb3288db52a3.png)
+![Charge Sequence Diagram](https://static.swimlanes.io/5c680355992a2ebd0f5be90a88e8651d.png)
 
 ### Risk Checks Failed (Init Payment Error)
 | Step |Command Type| Triggered by | Description |
@@ -534,6 +534,8 @@ For example, a response of GetPaymentInfo in which the refernce_id provided was 
 * `payment_type_mismatch` 
 * `invalid_command_type`
 * `unspecified_error`
+
+Note that the list of error codes above is non exhaustive. A VASP may choose to use values not specified in this list.
 
 ---
 # Appendix A - Prerequisite: Sharing Common Payment Identifier and Address

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -77,7 +77,7 @@ Protocols supporting other eCommerce payments flows will require additional paym
 Some examples for such flows are:
 * Auth / Capture
 * Subscription payment
-* Recurring payment
+* Recurring payments
 
 ---
 ## Sender / Receiver Interface

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -6,7 +6,7 @@ status: Draft
 type: Standard
 created: 03/15/2021
 updated: 05/23/2021
-requires: DIP-1, DIP-5, DIP-161
+requires: DIP-1, DIP-5, DIP-10, DIP-161
 ---
 
 # Summary
@@ -18,10 +18,12 @@ This DIP does NOT include payment flows which require funds pull pre-approval su
 
 This DIP makes use of the `result` field added to the `CommandResponseObject` as described in [DIP-161](https://github.com/diem/dip/blob/main/dips/dip-161.md)
 
+This DIP makes use of the `PaymentMetadata` enum as described in [DIP-10](https://github.com/diem/dip/blob/main/dips/dip-10.md#on-chain-transaction-settlement)
+
 ---
 # Abstract / Motivation
 This DIP is an extension of the Off-Chain Protocol to support more advanced payment functionality - particularly eCommerce P2M Charge payment.
-Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured (and submit a corresponding transaction on-chain and actually transfer the funds). 
+Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured and the existence of a corresponding transaction on-chain. 
 
 ## How P2M Payments Differ from P2P Transfers 
 There are several key differences between the process of paying a merchant (P2M) and a simple P2P transfer:
@@ -56,21 +58,23 @@ Content:
 * [Request / Response Payload](#request--response-payload)
 * [Structures](#new-structures)
 * [Appendix A: Sharing Common Payment Identifier and Address](#appendix-a---prerequisite-sharing-common-payment-identifier-and-address)
+* [Appendix B: Include Reference ID in the On-Chain Transaction](#appendix-b---include-reference-id-in-the-on-chain-transaction)
 ---
 ## High-Level Flow and Payment Types
 ---
 The high-level flow of an eCommerce P2M payment is:
 1. On the merchant's checkout page the customer chooses to pay with Diem
 2. The merchant transmits the payment details to its VASP (receiver VASP) so the latter can generate a payment request with Diem  
-3. The the receiver VASP generates a payment request with all details needed to identify this payment later in the process, provides it to the merchant and makes it available to the customer's Diem wallet (the customer's VASP or sender)
-4. The sender VASP parses the payment request (e.g. by scanning the payment request QR) and uses the provided payment identifier to get the payment details. This is the first step of the off-chain protocol
-5. The wallet then presents the requested payment details to the customer so the customer can review the payment
-6. The customer approves the payment request in the wallet
-7. The wallet initializes the payment protocol (off-chain) which will end (if successful) with the funds being charged. Successful completion implies that the receiving VASP was satisfied with the payer information provided and the sender VASP was satisfied with the merchant information provided. **Note** that if the payment amount exceeds the amount that requires a dual attestation signature to be submitted to the blockchain, it must be part of the on-chain transaction submitted  
+3. The receiver VASP generates a payment request with all details needed and provides it to the merchant, so the latter can display the Diem payment details in the checkout page
+4. The customer triggers the payment by performing the required actions in the checkout page, e.g. by scanning a QR code
+5. The sender VASP parses the payment request (e.g. parse the information encoded in the QR code) and uses the provided payment identifier to get the payment details. This is the first step of the off-chain protocol
+6. The wallet then presents the requested payment details to the customer so the customer can review the payment
+7. The customer approves the payment request in the wallet
+8. The wallet initializes the payment protocol (off-chain) which will end (if successful) with the funds being charged and a corresponsing transaction was put on-chain. Successful completion implies that the receiving VASP was satisfied with the payer information provided and the sender VASP was satisfied with the merchant information provided. **Note** that if the payment amount exceeds the amount that requires a dual attestation signature (i.e. above Travel Rule threshold), the receipient signature must be provided to the sender, so the latter can include it in the on-chain transaction submitted.  
 
 ### **Charge Payment Type** 
 Charge payment stipulates an immediate capture of funds. This means that a successful off-chain negotiation for such payment will result in funds being captured.
-As soon as the funds are captured, i.e. the sender agreed to the payment terms, the sender VASP is expected to submit a corresponding transaction on-chain and actually transfer the funds. 
+As soon as the funds are captured, i.e. the sender and receiver agreed to the payment terms, the sender VASP is expected to submit a corresponding transaction on-chain and actually transfer the funds. 
 
 ### **Other Payment Types (future)**
 Protocols supporting other eCommerce payments flows will require additional payment types which will be be defined in future DIPs.
@@ -85,18 +89,16 @@ Some examples for such flows are:
 This section describes a set of functionalities / activities that should be made available by a Sender and Receiver VASPs in order to support P2M Charge flow based on this DIP. Each functionality can be conceptually compared to an API endpoint. Similar to API documentation, it includes the expected input and output for each functionality.
 
 ## Command Types
-The following is a list of new values for the `command_type` field of the `CommandRequestObject`. Each command type denotes a step in the off-chain negotiations and specifies the data of the requests and the response 
+The following is a list of new values for the `command_type` field of the `CommandRequestObject`. Each command type denotes a step in the off-chain negotiations and specifies the data of the request and response 
 * `GetPaymentInfo` - Allows obtaining payment information based on reference id
-* `InitChargePayment` - Initializes a payment process of type `charge`
-* `ReadyForSettlementNotification` - Notifies the payment is ready for settlement on-chain
+* `InitChargePayment` - Initializes a payment process of type `charge`. Triggering this command by the wallet means the customer approved to proceed with the payment and that the wallet is satisified with the business infromation provided. Successful response from the receiver means that the receiver is satisfied with the payer data provided by the wallet 
 * `AbortPayment` - Aborts a payment
 
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
 |[GetPaymentInfo](#getpaymentinfo)|Sender > Receiver|By providing the object reference id the wallet can retrieve the object information from the receiving VASP. In most cases, this would be the first command sent by the wallet. The wallet is not expected to provide any payer data at this stage|Reference ID|Payment Details ; Business Data|
-|[InitChargePayment](#initchargepayment)|Sender > Receiver|This functionality allows the wallet to init the payment process based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data|(optional) Recipient Signature|
-|[ReadyForSettlementNotification](#readyforsettlementnotification)|Sender > Receiver|This functionality allows the wallet to indicate the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after declaring it is ready|Reference ID||
-|[AbortPayment](#abortpayment)|Sender > Receiver / Receiver > Sender|This functionality allows both parties to abort the payment. For example, the receiver may want to abort the payment following failed risk checks|Reference ID||
+|[InitChargePayment](#initchargepayment)|Sender > Receiver|This functionality allows the wallet to init the payment process based on the payment details. This is likely to occur after the customer approved the payment request and the wallet verified the business data|Reference ID ; Payer Data|(optional) Recipient Signature|
+|[AbortPayment](#abortpayment)|Sender > Receiver / Receiver > Sender|This functionality allows both parties to abort the payment outside the standard flow of the protocol|Reference ID||
 
 ---
 ## Payment Sequences
@@ -111,10 +113,12 @@ Each scenario is expressed using a sequence of Sender / Receiver functionality.
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
 |2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
-|3|ReadyForSettlementNotification|Sender|The wallet indicates the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after this step|
+|3|Put transaction on-chain|Sender|Following a successful response from the receiver (to the InitChargePayment in the previous step), the wallet must put a corresponding transaction on-chain and include the Reference ID as part of the metadata. See [appendix B](#appendix-b---include-reference-id-in-the-on-chain-transaction). If the payment is over the travel rule threshold, the sender must verify the recipient provided its signature as part of the InitChargePayment response|
+
+**Note** that following the completion of the Charge sequence, the receiver should start looking for the transaction put by the sender on the blockchain 
 
 #### Charge Sequence Diagram
-![Charge Sequence Diagram](https://static.swimlanes.io/5c680355992a2ebd0f5be90a88e8651d.png)
+![Charge Sequence Diagram](TBD)
 
 ### Risk Checks Failed (Init Payment Error)
 | Step |Command Type| Triggered by | Description |
@@ -122,30 +126,37 @@ Each scenario is expressed using a sequence of Sender / Receiver functionality.
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
 |2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data.  Risk checks failed. Receiver will respond with PaymentCommandErrorObject where the error_code is `risk_checks_failed`|
 
-### Invalid Command Type (Premature Settlement Error)
-| Step |Command Type| Triggered by | Description |
-|-|-|-|-|
-|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|ReadyForSettlementNotification|Sender|Instead of initializing the payment, the wallet wrongly notifies that the payment is ready for settlement. Receiver will respond with PaymentCommandErrorObject where the error_code is `invalid_command_type`|
-
 ### Abort Sequence - Customer Rejected the Payment Request
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|AbortPayment|Sender|Customer decided not to approve the payment based on the information displayed. It is recommended to include a descriptive abort_message|
+|2|AbortPayment|Sender|Customer decided not to approve the payment based on the information displayed. The abort_code is `customer_declined`. It is recommended to include a descriptive abort_message|
 
 ### Abort Sequence - Merchant Data Checks (performed by the Sender) Failed
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
-|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
-|2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
-|3|AbortPayment|Sender|Sender decided to abort. Can happen if the sender does not approve merchant data provided by the receiver|
+|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data|
+|2|AbortPayment|Sender|Sender decided to abort. Can happen if the sender does not approve merchant data provided by the receiver. The abort_code is `business_not_verified`. It is recommended to include a descriptive abort_message|
 
 ### Abort Sequence - Insufficient Funds
 | Step |Command Type| Triggered by | Description |
 |-|-|-|-|
 |1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data|
-|2|AbortPayment|Sender|After getting the payments details from the receiver, the wallet verifies the customer has sufficient funds to complete the payment. If not (and the customer cannot/does not top up the account balance), the wallet should respond with AbortPayment. It is recommended to include a descriptive abort_message|
+|2|AbortPayment|Sender|After getting the payments details from the receiver, the wallet verifies the customer has sufficient funds to complete the payment. If not (and the customer cannot/does not top up the account balance), the wallet should respond with AbortPayment. The abort_code is `insufficient_funds`. It is recommended to include a descriptive abort_message|
+
+### Abort Sequence - Missing Recipient Signature
+| Step |Command Type| Triggered by | Description |
+|-|-|-|-|
+|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
+|2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data. Since the payment is over the travel rule threshold, the wallet expects a recipient signature as part of the response|
+|3|AbortPayment|Sender|After getting the payments details from the receiver, the wallet verifies the recipient signature exists. If not, the wallet should respond with AbortPayment. The abort_code is `missing_recipient_signature`. It is recommended to include a descriptive abort_message|
+
+### Abort Sequence - Could Not Put Transaction On-Chain
+| Step |Command Type| Triggered by | Description |
+|-|-|-|-|
+|1|GetPaymentInfo|Sender|The wallet requests payment details using the reference id provided. The receiver will respond with the payment details and merchant data. The wallet will display the payment details so the customer can approve or reject|
+|2|InitChargePayment|Sender|Following customer approval the wallet initializes the payment process and sends the payer data|
+|3|AbortPayment|Sender|After getting the payments details from the receiver, for some reason, the wallet is not able to put the transaction on-chain. The wallet should respond with AbortPayment. The abort_code is `could_not_put_transaction`. It is recommended to include a descriptive abort_message|
 
 ---
 ## Request / Response Payload
@@ -216,7 +227,7 @@ Field|Type|Required?|Description|
 ### InitChargePayment
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
-|InitChargePayment|Sender > Receiver|This functionality allows the wallet to init the payment process for payments of type `charge` based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data|(optional) Recipient Signature|
+|InitChargePayment|Sender > Receiver|This functionality allows the wallet to init the payment process for payments of type `charge` based on the payment details. This is likely to occur after the customer approved the payment request and the wallet verified the business data. Successful response from the receiver means that the receiver is willing to accept the funds and the wallet is expected to put a transaction on-chain|Reference ID ; Payer Data|(optional) Recipient Signature|
 
 #### InitChargePayment Request
 Field|Type|Required?|Description|
@@ -273,45 +284,17 @@ Field|Type|Required?|Description|
 }
 
 ```
-### ReadyForSettlementNotification
-| Command Type |Direction| Description | Request Data | Response Data |
-|-|-|-|-|-|
-|ReadyForSettlementNotification|Sender > Receiver|This functionality allows the wallet to indicate the payment is ready for settlement. The wallet is expected to submit a transaction on-chain immediately before or after declaring it is ready|Reference ID||
-
-#### ReadyForSettlementNotification Request
-Field|Type|Required?|Description|
-|-|-|-|-|
-|reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
-```
-{
-  "_ObjectType": "CommandRequestObject",
-  "command_type": "ReadyForSettlementNotification",
-  "cid": "3185027f-0574-6f55-2668-3a38fdb5de98",
-  "command": {
-    "_ObjectType": "ReadyForSettlementNotification",      
-    "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98"
-  }
-}
-
-```
-#### ReadyForSettlementNotification Response
-```
-{
-  "_ObjectType": "CommandResponseObject",
-  "status": "success",
-  "cid": "12ce83f6-6d18-0d6e-08b6-c00fdbbf085a"    
-}
-```
 ### AbortPayment
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
-|AbortPayment|Sender > Receiver / Receiver > Sender|This functionality allows both parties to abort the payment. For example, the receiver may want to abort the payment following failed risk checks|Reference ID|| 
+|AbortPayment|Sender > Receiver / Receiver > Sender|This functionality allows both parties to abort the payment outside the standard flow of the protocol|Reference ID|| 
 
 
 #### AbortPayment Request
 Field|Type|Required?|Description|
 |-|-|-|-|
 |reference_id|str|Y|Unique reference ID of this payment. This value should be globally unique|
+|abort_code |[AbortCode enum](#abortcode-enum)|N| This field is used to specify the reason for the abort|
 |abort_message|str|N|Additional information about the reason for aborting this payment|
 ```
 {
@@ -321,6 +304,7 @@ Field|Type|Required?|Description|
   "command": {
     "_ObjectType": "AbortPayment",    
     "reference_id": "4185027f-0574-6f55-2668-3a38fdb5de98",
+    "abort_code": "customer_declined",
     "abort_message": "abort message"
   }
 }
@@ -537,6 +521,16 @@ For example, a response of GetPaymentInfo in which the refernce_id provided was 
 
 Note that the list of error codes above is non exhaustive. A VASP may choose to use values not specified in this list.
 
+### AbortCode Enum
+* `insufficient_funds`
+* `customer_declined`
+* `business_not_verified`
+* `missing_recipient_signature` 
+* `could_not_put_transaction`
+* `unspecified_error`
+
+Note that the list of error codes above is non exhaustive. A VASP may choose to use values not specified in this list.
+
 ---
 # Appendix A - Prerequisite: Sharing Common Payment Identifier and Address
 
@@ -598,3 +592,18 @@ The deeplink represented by QR code would be (the domain and path are examples -
 `diem://some-diem-wallet.com/pay?vasp_address=dm1pgxah7pxhzljvp3p4m9g0m3tm0qqqqqqqqqqqqqqgyftgh&reference_id=ad8d888a-1791-4b63-98e5-6f1d6ddb4411`
 
 After scanning the QR code, the wallet can request the payment details from the receiving VASP and display them to the customer to review and approve.
+
+---
+# Appendix B - Include Reference ID in the On-Chain Transaction
+
+In order for the receiver VASP to be able to correlate the on-chain transaction to the off-chain payment, the sender VASP must include the Reference ID in the on-chain transaction metadata.
+Using the Reference ID for correlation, the receiver VASP can, for example, verify that the amount in the on-chain transaction matches the off-chain payment amount.
+
+The Reference ID must be added to the PaymentMetadata element defined in [DIP-10](https://github.com/diem/dip/blob/main/dips/dip-10.md#on-chain-transaction-settlement).
+```
+enum PaymentMetadata {
+    PaymentMetadataV0(ReferenceId),
+}
+type ReferenceId = [u8, 16];
+``` 
+

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -118,7 +118,7 @@ Each scenario is expressed using a sequence of Sender / Receiver functionality.
 **Note** that following the completion of the Charge sequence, the receiver should start looking for the transaction put by the sender on the blockchain 
 
 #### Charge Sequence Diagram
-![Charge Sequence Diagram](TBD)
+TBD
 
 ### Risk Checks Failed (Init Payment Error)
 | Step |Command Type| Triggered by | Description |

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -52,8 +52,8 @@ This section specifies P2M payment type, required structures, payloads and expec
 Content:
 * [High Level Flow and Payment Types](#high-level-flow-and-payment-types)
 * [Sender / Receiver Interface](#sender--receiver-interface)
-* [Request / Response Payload](#request--response-payload)
 * [Payment Sequences](#payment-sequences)
+* [Request / Response Payload](#request--response-payload)
 * [Structures](#new-structures)
 * [Appendix A: Sharing Common Payment Identifier and Address](#appendix-a---prerequisite-sharing-common-payment-identifier-and-address)
 ---
@@ -73,7 +73,7 @@ Charge payment stipulates an immediate capture of funds. This means that a succe
 As soon as the funds are captured, i.e. the sender agreed to the payment terms, the sender VASP is expected to submit a corresponding transaction on-chain and actually transfer the funds. 
 
 ### **Other Payment Types (future)**
-More advanced eCommerce payments flows will require additional payment types which will be be defined in future DIPs.
+Protocols supporting other eCommerce payments flows will require additional payment types which will be be defined in future DIPs.
 Some examples for such flows are:
 * Auth / Capture
 * Subscription payment

--- a/dips/dip-158.md
+++ b/dips/dip-158.md
@@ -216,7 +216,7 @@ Field|Type|Required?|Description|
 ### InitChargePayment
 | Command Type |Direction| Description | Request Data | Response Data |
 |-|-|-|-|-|
-|InitChargePayment|Sender > Receiver|This functionality allows the wallet to init the payment process for payments of type `charge` based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data||
+|InitChargePayment|Sender > Receiver|This functionality allows the wallet to init the payment process for payments of type `charge` based on the payment details. For example, this may occur after the customer approved the payment request|Reference ID ; Payer Data|(optional) Recipient Signature|
 
 #### InitChargePayment Request
 Field|Type|Required?|Description|


### PR DESCRIPTION
- Removed ReadyForSettlement command
- Added expectation for the Merchant VASP to find transaction on the blockchain
- Added abort codes for the AbortPayment command
- Added abort sequences (Missing Recipient Signature, Could Not Put Transaction On-Chain)
- Added appendix about including the reference ID in the transaction metadata (including reference to DIP-10)
- Removed sequence diagram temporarily (until we upload the final image to github and embed from there)