### PR TITLE
[DIP 169] remove section on designated dealers

### DIFF
--- a/dips/dip-169.md
+++ b/dips/dip-169.md
@@ -25,27 +25,6 @@ Currently in the Diem Framework, a transaction acts on behalf of a single on-cha
 
 # Motivation/Use Cases
 
-## Minting Directly to VASPs
-
-Today in the Diem Framework, we need two transactions in order to mint money through designated dealers to VASPs. The first transaction is a transaction sent by the treasury compliance account to mint money into a designated dealer’s account. The second, decoupled transaction transfers the minted funds from the designated dealer’s account into a VASP’s account. This procedure requires two transactions due to the restriction that each transaction can only have one signer argument, despite this being a multi-party flow.
-
-This restriction no longer exists in our proposed multi-agent scheme and we can perform both steps in a single atomic transaction (see code sample below). This atomicity implies that designated dealers no longer need custody services for the money they temporarily hold in their accounts, making it more affordable and much quicker to operate as a designated dealer. This should make it much easier for more DDs to onboard in the Diem ecosystem, providing more options for VASPs. It is highly likely that in the future, DDs primarily mint directly on requests from VASPs.
-
-```rust
-fun mint<Coin>(
-   tc: signer,
-   dd: signer,
-   vasp_addr: address,
-   amount: u64,
-   tier_index: u64
-) {
-   // Mint funds directly to VASP.
-   mint_to_vasp<Coin>(tc, dd, vasp_addr, amount);
-}
-```
-
-
-
 ## Atomic Swaps
 
 In order to do a currency exchange in the current scheme between two on-chain entities Alice and Bob, we need two transactions and possibly an escrow. The time gap between the two transactions can lead to potential problems such as resource lockup. With the new multi-agent transaction scheme, we only need one atomic transaction signed by both Alice and Bob, in which payments are sent in both directions (see the code sample below). In this case, both Alice and Bob have the same control over the transaction contents including exchange rates and expiration time.


### PR DESCRIPTION
This PR removes references to designated dealers in DIP 169 since the use case is no longer applicable.